### PR TITLE
Add default menu and order item in order screen.

### DIFF
--- a/src/assets/sampleMenu.js
+++ b/src/assets/sampleMenu.js
@@ -1,0 +1,16 @@
+const menu = [
+    {
+        name: "salmon spaghetti",
+        price: 10
+    },
+    {
+        name: "rice pudding",
+        price: 3
+    },
+    {
+        name: "mint ice cream",
+        price: 5
+    }
+]
+
+export default menu

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import Charcuterie from 'pages/Charcuterie';
 import CreateSession from 'pages/CreateSession';
+import OrderScreen from 'pages/OrderScreen';
 import reportWebVitals from './utils/reportWebVitals';
 import { BrowserRouter, Route, Link, Switch } from "react-router-dom";
 
@@ -15,6 +16,9 @@ ReactDOM.render(
       <Switch>
         <Route path="/create-session">
           <CreateSession />
+        </Route>
+        <Route path="/order-screen">
+          <OrderScreen />
         </Route>
         <Route path="/">
           <Charcuterie />

--- a/src/pages/CreateSession.js
+++ b/src/pages/CreateSession.js
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import Button from 'components/Button'
 import Input from 'components/Input'
 import { Title, H2 } from 'styles/styleUtils';
+import { useHistory } from 'react-router-dom';
 
 const PageContainer = styled.div`
 display: flex;
@@ -21,6 +22,13 @@ flex-direction: row;
 `;
 
 function CreateSession({ ...props }) {
+    const history = useHistory();
+
+    // TODO: Ask server for a session and navigate to custom session ??? unscoped
+    const generateSession = () => {
+        history.push('/order-screen')
+    }
+
     return (
         <Theme>
             <PageContainer>
@@ -36,7 +44,7 @@ function CreateSession({ ...props }) {
                     <Input size={"medium"} label={"Event Name"} placeholder={"Dine Out"} />
                 </InputContainer>
                 <br />
-                <Button size={"medium"} type={"primary"} label={"Create Session"} />
+                <Button size={"medium"} type={"primary"} label={"Create Session"} onClick={generateSession}/>
             </PageContainer>
         </Theme>
     );

--- a/src/pages/OrderScreen.js
+++ b/src/pages/OrderScreen.js
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from "react";
+import { OrderContext } from "utils/Context";
+import sampleMenu from "assets/sampleMenu";
+
+function OrderScreen() {
+  const [order, setOrder] = useState(null);
+
+  // TODO: get menu from server
+  const fetchMenu = () => {
+    return sampleMenu;
+  };
+
+  // TODO: send order to server & attach userId
+  const sendOrder = () => {};
+
+  // TODO: get group total (including tips) from server
+  const getGroupTotals = () => {};
+
+  // TODO: history.push to next page with data
+  const consolidateOrder = () => {}
+
+  useEffect(() => {
+    // TODO: Perhaps implement webhook (socket) to listen for additional users
+    const initializeOrder = () => {
+      const menu = fetchMenu();
+      return menu.map((item) => ({ ...item, quantity: 0 }));
+    };
+    setOrder(initializeOrder());
+  }, []);
+
+  return (
+    <OrderContext.Provider value={[order, setOrder]}>
+      {JSON.stringify(order)}
+    </OrderContext.Provider>
+  );
+}
+
+export default OrderScreen;

--- a/src/utils/Context.js
+++ b/src/utils/Context.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react'
+
+export const OrderContext = createContext();


### PR DESCRIPTION
Fixes: #28 

Add order context provider for children to use
- beneficial if "grand children" need to use them
- beneficial to share multiple things commonly used together

Added sample menu and order JSON object

Created `OrderScreen` page

Added some dummy methods

Added dummy nav from create session