### PR TITLE
added disable to quantity selector

### DIFF
--- a/client/src/components/MenuSelector.js
+++ b/client/src/components/MenuSelector.js
@@ -43,7 +43,7 @@ const formatter = new Intl.NumberFormat("en-US", {
 
 formatter.format(2500); /* $2,500.00 */
 
-const MenuRow = ({ className, orderItem, updateQuantity, initQuantity }) => {
+const MenuRow = ({ className, orderItem, updateQuantity, initQuantity, disableSelect }) => {
   const [quantity, setQuantity] = useState(initQuantity);
   useEffect(() => {
     updateQuantity(orderItem.name, quantity);
@@ -53,7 +53,7 @@ const MenuRow = ({ className, orderItem, updateQuantity, initQuantity }) => {
       <MenuItemRowData>{orderItem.name}</MenuItemRowData>
       <MenuItemRowData>{formatter.format(orderItem.price)}</MenuItemRowData>
       <MenuItemRowData>
-        <QuantitySelector value={quantity} setValue={setQuantity} />
+        <QuantitySelector value={quantity} setValue={setQuantity} disable={disableSelect} />
       </MenuItemRowData>
     </MenuItemRow>
   );
@@ -66,7 +66,7 @@ const handleHideCategory = (category) => {
   }
 };
 
-const MenuSelector = ({ order, updateQuantity }) => {
+const MenuSelector = ({ order, updateQuantity, disableSelect }) => {
   const orderItems = order ?? [];
   const categorizeItems = (orders) => {
     const categorizedItems = {};
@@ -106,6 +106,7 @@ const MenuSelector = ({ order, updateQuantity }) => {
                       initQuantity={quantity}
                       // HACK
                       updateQuantity={updateQuantity ?? ((a, b) => null)}
+                      disableSelect={disableSelect}
                     />
                   );
                 })}

--- a/client/src/components/QuantitySelector.js
+++ b/client/src/components/QuantitySelector.js
@@ -38,15 +38,19 @@ const QuantitySelectorInput = styled.input`
   }
 `;
 
-const QuantitySelector = ({ value, setValue, ...props }) => (
+const QuantitySelector = ({ value, setValue, disable, ...props }) => (
   <>
-    <QuantityButton onClick={() => handleDecrease(value, setValue)}>
-      <FaMinus />
-    </QuantityButton>
+    {!disable &&
+      <QuantityButton onClick={() => handleDecrease(value, setValue)}>
+        <FaMinus />
+      </QuantityButton>
+    }
     <QuantitySelectorInput value={value} readonly disabled {...props} />
+    {!disable &&
     <QuantityButton onClick={() => handleIncrease(value, setValue)}>
       <FaPlus />
     </QuantityButton>
+    }
   </>
 );
 

--- a/client/src/pages/FinalOrder.js
+++ b/client/src/pages/FinalOrder.js
@@ -65,7 +65,7 @@ function FinalOrder() {
           </TextIcon>
           <StyledHeader>Final Order Summary</StyledHeader>
           <MenuContainer>
-            <MenuSelector order={order}/>
+            <MenuSelector order={order} disableSelect={true}/>
           </MenuContainer>
           <TotalAmount
             size={"medium"}


### PR DESCRIPTION
when the disabled prop is passed into the quantity selector, the +/- signs will not be displayed so that users cannot change the quantity in the menu component on the final summary page 

enabled: 
![image](https://user-images.githubusercontent.com/62684843/128846601-c8650b74-cf7c-4173-9746-06c95ee62503.png)

disabled:
![image](https://user-images.githubusercontent.com/62684843/128846802-b940c081-a4bb-4a7b-99ae-947a747b88ce.png)
